### PR TITLE
Normalize heading levels in HTML content

### DIFF
--- a/src/__tests__/headingNormalization.test.ts
+++ b/src/__tests__/headingNormalization.test.ts
@@ -1,0 +1,99 @@
+import { normalizeHeadingLevels } from '../html/post/headings';
+
+describe('normalizeHeadingLevels', () => {
+    const parse = (html: string): HTMLElement => {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        return doc.body;
+    };
+
+    it('should normalize skipped levels (h2 -> h5 => h2 -> h3)', () => {
+        const body = parse(`
+            <h2>Title</h2>
+            <p>Text</p>
+            <h5>Subtitle</h5>
+            <p>More text</p>
+        `);
+
+        normalizeHeadingLevels(body);
+
+        expect(body.innerHTML).toContain('<h2>Title</h2>');
+        expect(body.innerHTML).toContain('<h3>Subtitle</h3>');
+        expect(body.innerHTML).not.toContain('<h5>');
+    });
+
+    it('should preserve sequential levels', () => {
+        const body = parse(`
+            <h1>Title</h1>
+            <h2>Subtitle</h2>
+            <h3>Sub-subtitle</h3>
+        `);
+
+        normalizeHeadingLevels(body);
+
+        expect(body.innerHTML).toContain('<h1>Title</h1>');
+        expect(body.innerHTML).toContain('<h2>Subtitle</h2>');
+        expect(body.innerHTML).toContain('<h3>Sub-subtitle</h3>');
+    });
+
+    it('should preserve deep start levels (h4 -> h6 => h4 -> h5)', () => {
+        const body = parse(`
+            <h4>Deep Title</h4>
+            <h6>Deep Subtitle</h6>
+        `);
+
+        normalizeHeadingLevels(body);
+
+        expect(body.innerHTML).toContain('<h4>Deep Title</h4>');
+        expect(body.innerHTML).toContain('<h5>Deep Subtitle</h5>');
+        expect(body.innerHTML).not.toContain('<h6>');
+    });
+
+    it('should preserve attributes when replacing tags', () => {
+        const body = parse(`
+            <h2 id="main" class="title">Main</h2>
+            <h5 id="sub" data-test="value">Sub</h5>
+        `);
+
+        normalizeHeadingLevels(body);
+
+        const h2 = body.querySelector('h2');
+        const h3 = body.querySelector('h3');
+
+        expect(h2).not.toBeNull();
+        expect(h2?.getAttribute('id')).toBe('main');
+        expect(h2?.getAttribute('class')).toBe('title');
+
+        expect(h3).not.toBeNull();
+        expect(h3?.getAttribute('id')).toBe('sub');
+        expect(h3?.getAttribute('data-test')).toBe('value');
+    });
+
+    it('should handle mixed levels correctly', () => {
+        const body = parse(`
+            <h2>1</h2>
+            <h5>2</h5>
+            <h2>3</h2>
+            <h6>4</h6>
+        `);
+
+        // Levels present: 2, 5, 6
+        // Sorted: 2, 5, 6
+        // Mapping: 2->2, 5->3, 6->4
+
+        normalizeHeadingLevels(body);
+
+        const headings = body.querySelectorAll('h1, h2, h3, h4, h5, h6');
+        expect(headings.length).toBe(4);
+        expect(headings[0].tagName).toBe('H2');
+        expect(headings[1].tagName).toBe('H3');
+        expect(headings[2].tagName).toBe('H2');
+        expect(headings[3].tagName).toBe('H4');
+    });
+
+    it('should do nothing if no headings present', () => {
+        const body = parse('<p>Just text</p>');
+        normalizeHeadingLevels(body);
+        expect(body.innerHTML).toBe('<p>Just text</p>');
+    });
+});

--- a/src/html/passes/registry.ts
+++ b/src/html/passes/registry.ts
@@ -5,7 +5,7 @@ import { pruneNonImageAnchorChildren } from '../pre/imageAnchorCleanup';
 import { removeGoogleDocsWrappers } from '../pre/wrapperCleanup';
 import { neutralizeCodeBlocksPreSanitize } from '../pre/codeNeutralize';
 import { removeEmptyAnchors, cleanHeadingAnchors } from '../post/anchors';
-import { stripHeadingFormatting } from '../post/headings';
+import { stripHeadingFormatting, normalizeHeadingLevels } from '../post/headings';
 import { protectLiteralHtmlTagMentions } from '../post/literals';
 import { fixOrphanNestedLists, unwrapCheckboxParagraphs, unwrapInvalidListWrappers } from '../post/lists';
 import { normalizeCodeBlocks, markNbspOnlyInlineCode } from '../post/codeBlocks';
@@ -67,6 +67,12 @@ const POST_SANITIZE_PASSES: readonly ProcessingPass[] = [
         phase: 'post-sanitize',
         priority: 20,
         execute: (body) => cleanHeadingAnchors(body),
+    },
+    {
+        name: 'Post-sanitize heading level normalization',
+        phase: 'post-sanitize',
+        priority: 21,
+        execute: (body) => normalizeHeadingLevels(body),
     },
     {
         name: 'Post-sanitize plain heading text enforcement',

--- a/src/html/post/headings.ts
+++ b/src/html/post/headings.ts
@@ -23,3 +23,52 @@ export function stripHeadingFormatting(body: HTMLElement): void {
         heading.textContent = normalized;
     });
 }
+
+/**
+ * Normalizes heading levels to be sequential.
+ * E.g. if a document has h2, then h5, then h6, it will be normalized to h2, h3, h4.
+ * The starting level is preserved (so if it starts at h2, it stays h2).
+ */
+export function normalizeHeadingLevels(body: HTMLElement): void {
+    const headings = Array.from(body.querySelectorAll<HTMLElement>('h1, h2, h3, h4, h5, h6'));
+    if (headings.length === 0) return;
+
+    // 1. Identify unique levels present
+    const levels = new Set<number>();
+    headings.forEach((h) => {
+        const level = parseInt(h.tagName.substring(1), 10);
+        levels.add(level);
+    });
+
+    // 2. Create mapping from old level to new level
+    const sortedLevels = Array.from(levels).sort((a, b) => a - b);
+    const mapping = new Map<number, number>();
+    const startLevel = sortedLevels[0];
+
+    sortedLevels.forEach((oldLevel, index) => {
+        mapping.set(oldLevel, startLevel + index);
+    });
+
+    // 3. Apply mapping
+    headings.forEach((h) => {
+        const oldLevel = parseInt(h.tagName.substring(1), 10);
+        const newLevel = mapping.get(oldLevel);
+
+        if (newLevel && newLevel !== oldLevel) {
+            const newTag = `H${newLevel}`;
+            const newHeading = h.ownerDocument.createElement(newTag);
+
+            // Copy attributes
+            Array.from(h.attributes).forEach((attr) => {
+                newHeading.setAttribute(attr.name, attr.value);
+            });
+
+            // Move children
+            while (h.firstChild) {
+                newHeading.appendChild(h.firstChild);
+            }
+
+            h.replaceWith(newHeading);
+        }
+    });
+}


### PR DESCRIPTION
Normalize heading levels

Ensure each heading is at most 1 level deeper than the previous heading, e.g. if a document has h2, h5, h6, it will be normalized to h2, h3, h4.